### PR TITLE
ipq40xx: convert ZTE MF286D to DSA

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -155,9 +155,7 @@ ipq40xx_setup_interfaces()
 			"0u@eth0" "1:lan" "2:lan" "3:lan" "4:lan" "0u@eth1" "5:wan"
 		;;
 	zte,mf286d)
-		ucidef_set_interfaces_lan_wan "eth0" "eth1"
-		ucidef_add_switch "switch0" \
-			"0u@eth0" "2:lan:4" "3:lan:3" "4:lan:2" "0u@eth1" "5:wan"
+		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4" "wan"
 		;;
 	*)
 		echo "Unsupported hardware. Network interfaces not initialized"

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-mf286d.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-mf286d.dts
@@ -217,6 +217,12 @@
 	status = "okay";
 };
 
+&gmac {
+	status = "okay";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_config_0>;
+};
+
 &nand {
 	pinctrl-0 = <&nand_pins>;
 	pinctrl-names = "default";
@@ -317,6 +323,33 @@
 
 &qpic_bam {
 	status = "okay";
+};
+
+&switch {
+	status = "okay";
+};
+
+&swport2 {
+	status = "okay";
+	label = "lan4";
+};
+
+&swport3 {
+	status = "okay";
+	label = "lan3";
+};
+
+&swport4 {
+	status = "okay";
+	label = "lan2";
+};
+
+&swport5 {
+	status = "okay";
+	label = "wan";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_config_0>;
+	mac-address-increment = <1>;
 };
 
 &tlmm {


### PR DESCRIPTION
Signed-off-by: Lech Perczak <lech.perczak@gmail.com>

Running the conversion from around the device introduction to master, albeit on older tree - just rebased now.
Port 5 is labeled as "LAN1/WAN" - keeping the intention of original author here, personally I'm running it as if it were "LAN1", the same as it its primary role on stock firmware.