### PR TITLE
Convert R619AC to DSA

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -17,6 +17,8 @@ ipq40xx_setup_interfaces()
 	linksys,ea6350v3|\
 	mikrotik,hap-ac2|\
 	mikrotik,hap-ac3|\
+	p2w,r619ac-64m|\
+	p2w,r619ac-128m|\
 	zyxel,nbg6617)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
 		;;
@@ -74,9 +76,7 @@ ipq40xx_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0t@eth0" "4:lan" "5:wan"
 		;;
-	asus,rt-ac42u|\
-	p2w,r619ac-64m|\
-	p2w,r619ac-128m)
+	asus,rt-ac42u)
 		ucidef_set_interfaces_lan_wan "eth0" "eth1"
 		ucidef_add_switch "switch0" \
 			"0u@eth0" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1"

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-r619ac.dtsi
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-r619ac.dtsi
@@ -336,6 +336,42 @@
 	status = "okay";
 };
 
+&gmac {
+	status = "okay";
+};
+
+&switch {
+	status = "okay";
+};
+
+&swport1 {
+	status = "okay";
+
+	label = "lan4";
+};
+
+&swport2 {
+	status = "okay";
+
+	label = "lan3";
+};
+
+&swport3 {
+	status = "okay";
+
+	label = "lan2";
+};
+
+&swport4 {
+	status = "okay";
+
+	label = "lan1";
+};
+
+&swport5 {
+	status = "okay";
+};
+
 &wifi0 {
 	status = "okay";
 	nvmem-cell-names = "pre-calibration";


### PR DESCRIPTION
Signed-off-by: ChunAm See <z1250747241@gmail.com>

I think this should be able to be merged without any MAC issues. But I have encountered 
1. when the wan port is set to pppoe protocol, it causes the device on port lan{1,2,3,4} to be unable to access any service located on the router during pppoe dial-up. 
(When the wan port is not plugged into the Internet cable or the pppoe process ends successfully, there is no such problem)
2. the network performance seems to degrade badly under DSA driver, is there any way to improve it?
~~(For example, adjusting the irq of tx/rx, in the [IPQ40x8,IPQ40x9-Software-guide.pdf](https://github.com/Deoptim/atheros/blob/master/IPQ40x8%2CIPQ40x9-Software-guide.pdf) , there is a recommendation to have tx{0,1,2,3},tx{4,5,6,7}.tx{8,9,10,11},tx{12,13,14,15} assigned to CPU2, CPU3, CPU0, CPU1; rx0, rx2, rx4, rx6 assigned to CPU0, CPU1, CPU2, CPU3, the important thing is that this guide is also valid for the drivers currently used in openwrt)~~
it looks like nftables/fw4's problem
