### PR TITLE
ipq40xx: convert cm520-79f to DSA

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq40xx/base-files/etc/board.d/01_leds
@@ -77,9 +77,9 @@ mikrotik,sxtsq-5-ac)
 	ucidef_set_led_rssi "rssihigh" "rssihigh" "green:rssihigh" "wlan0" "81" "100"
 	;;
 mobipromo,cm520-79f)
-	ucidef_set_led_netdev "wan" "WAN" "blue:wan" "eth1"
-	ucidef_set_led_switch "lan1" "LAN1" "blue:lan1" "switch0" "0x10"
-	ucidef_set_led_switch "lan2" "LAN2" "blue:lan2" "switch0" "0x08"
+	ucidef_set_led_netdev "wan" "WAN" "blue:wan" "wan"
+	ucidef_set_led_netdev "lan1" "LAN1" "blue:lan1" "lan1"
+	ucidef_set_led_netdev "lan2" "LAN2" "blue:lan2" "lan2"
 	;;
 netgear,ex6100v2 |\
 netgear,ex6150v2)

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -126,11 +126,6 @@ ipq40xx_setup_macs()
 		lan_mac=$(cat /sys/firmware/mikrotik/hard_config/mac_base)
 		label_mac="$lan_mac"
 		;;
-	mobipromo,cm520-79f)
-		wan_mac=$(mtd_get_mac_binary "ART" 0x1006)
-		lan_mac=$(mtd_get_mac_binary "ART" 0x5006)
-		label_mac=$wan_mac
-		;;
 	pakedge,wr-1)
 		wan_mac=$(macaddr_add $(get_mac_label) 1)
 	esac

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -48,7 +48,8 @@ ipq40xx_setup_interfaces()
 	cellc,rtl30vw)
 		ucidef_set_interface_lan "lan1 lan2"
 		;;
-	glinet,gl-b1300)
+	glinet,gl-b1300|\
+	mobipromo,cm520-79f)
 		ucidef_set_interfaces_lan_wan "lan1 lan2" "wan"
 		;;
 	compex,wpj428)
@@ -124,6 +125,11 @@ ipq40xx_setup_macs()
 	mikrotik,sxtsq-5-ac)
 		lan_mac=$(cat /sys/firmware/mikrotik/hard_config/mac_base)
 		label_mac="$lan_mac"
+		;;
+	mobipromo,cm520-79f)
+		wan_mac=$(mtd_get_mac_binary "ART" 0x1006)
+		lan_mac=$(mtd_get_mac_binary "ART" 0x5006)
+		label_mac=$wan_mac
 		;;
 	pakedge,wr-1)
 		wan_mac=$(macaddr_add $(get_mac_label) 1)

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-cm520-79f.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-cm520-79f.dts
@@ -344,6 +344,9 @@
 
 &gmac {
 	status = "okay";
+	nvmem-cells = <&macaddr_art_5006>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <1>;
 };
 
 &switch {

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-cm520-79f.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-cm520-79f.dts
@@ -117,7 +117,7 @@
 	leds {
 		compatible = "gpio-leds";
 
-		usb {
+		led_usb: usb {
 			label = "blue:usb";
 			gpios = <&tlmm 10 GPIO_ACTIVE_HIGH>;
 			linux,default-trigger = "usbport";
@@ -339,6 +339,30 @@
 };
 
 &usb2_hs_phy {
+	status = "okay";
+};
+
+&gmac {
+	status = "okay";
+};
+
+&switch {
+	status = "okay";
+};
+
+&swport3 {
+	status = "okay";
+
+	label = "lan2";
+};
+
+&swport4 {
+	status = "okay";
+
+	label = "lan1";
+};
+
+&swport5 {
 	status = "okay";
 };
 


### PR DESCRIPTION
Tested on my own device mobipromo cm520-79f.
All ports and leds work normally.