### PR TITLE
ipq40xx: convert ASUS Lyra MAP-AC2200 to DSA

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -22,6 +22,7 @@ ipq40xx_setup_interfaces()
 		;;
 	8dev,jalapeno|\
 	alfa-network,ap120c-ac|\
+	asus,map-ac2200|\
 	cilab,meshpoint-one|\
 	glinet,gl-b2200)
 		ucidef_set_interfaces_lan_wan "lan" "wan"
@@ -62,7 +63,6 @@ ipq40xx_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0u@eth0" "2:lan:1" "3:lan:2" "4:lan:3" "0u@eth1" "5:wan"
 		;;
-	asus,map-ac2200|\
 	edgecore,ecw5211|\
 	edgecore,oap100|\
 	google,wifi|\

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-map-ac2200.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-map-ac2200.dts
@@ -14,6 +14,7 @@
 		led-failsafe = &led_red0;
 		led-running = &led_blue0;
 		led-upgrade = &led_red0;
+		ethernet1 = &swport4;
 	};
 
 	soc {
@@ -311,4 +312,24 @@
 	pinctrl-0 = <&serial_pins>;
 	pinctrl-names = "default";
 	status = "okay";
+};
+
+&gmac {
+	status = "okay";
+};
+
+&switch {
+	status = "okay";
+};
+
+&swport4 {
+	status = "okay";
+
+	label = "wan";
+};
+
+&swport5 {
+	status = "okay";
+
+	label = "lan";
 };


### PR DESCRIPTION
@ondoteam please test. You should activate WiFi by default, so you can still access the device easily:
https://openwrt.org/docs/guide-developer/uci-defaults
For example:
```
cat << "EOF" > /etc/uci-defaults/99-custom
uci -q batch << EOI
set wireless.@wifi-device[0].disabled='0'
commit wireless
EOI
EOF
```